### PR TITLE
Feat: get working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+dist

--- a/README.md
+++ b/README.md
@@ -59,6 +59,36 @@ npx @chakra-ui/codemod <transform> <path>
 
 Note: Some components can be grouped together eg. Progress and Switch share a common migration step, so we can group under "rename-color-to-colorscheme".
 
+## Development
+
+To watch and build TS files run:
+
+```bash
+yarn watch   
+```
+
+Link this package in your global `node_modules` by running:
+
+```bash
+yarn link
+```
+
+To execute the command run:
+
+```bash
+# no path
+chakra-codemod
+> Run chakra codemod in: <current-directory>
+
+# relative path
+chakra-codemod my-app
+> Run chakra codemod in: <current-directory>/my-app
+
+# absolute path
+chakra-codemod /Users/you/development/my-app
+> Run chakra codemod in: /Users/you/development/my-app
+```
+
 ## References
 
 - https://skovy.dev/jscodeshift-custom-transform/

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ yarn watch
 Link this package in your global `node_modules` by running:
 
 ```bash
-yarn link
+npm link
 ```
 
 To execute the command run:

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+import chalk from "chalk";
+import path from "path";
+
+function getWorkingDir() {
+  const workingDir = path.resolve(process.argv[2] || process.cwd());
+
+  if (!workingDir || !fs.existsSync(workingDir)) {
+    console.log(
+      chalk.yellow`Invalid working dir: ${workingDir}. Please pass a valid path`,
+    );
+    process.exit(1);
+  }
+
+  return workingDir;
+}
+
+export async function bootstrap() {
+  const workingDir = getWorkingDir();
+  console.log(`${chalk.blue`Run chakra codemod in: `}${chalk(workingDir)}`);
+}
+
+bootstrap().catch((e) => {
+  console.error(e.message);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -20,16 +20,23 @@
     "@types/jest": "^26.0.15",
     "@types/node": "^14.14.7",
     "@types/jscodeshift": "^0.7.1",
-    "typescript": "^4.0.5"
+    "typescript": "^4.0.5",
+    "rimraf": "^3.0.2",
+    "prettier": "^2.1.2"
   },
   "files": [
-    "transforms/*.js",
-    "bin/*.js"
+    "dist/transforms/*.js",
+    "dist/bin/*.js"
   ],
   "scripts": {
     "transform": "jscodeshift --parser=tsx -t bin/cli.js  src/* --print --dry",
     "check:types": "tsc --noEmit",
+    "clean": "rimraf dist",
+    "build": "npm run clean && tsc",
+    "watch": "npm run build -- -w",
     "test": "jest"
   },
-  "bin": "./bin/next-codemod.js"
+  "bin": {
+    "chakra-codemod": "./dist/bin/cli.js"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,9 @@
     "esModuleInterop": true,
     "target": "es6",
     "strict": false,
-    "jsx": "preserve"
-  }
+    "jsx": "preserve",
+    "lib": ["es2017"], // node >=8
+    "outDir": "dist"
+  },
+  "exclude": ["**/__testfixtures__", "**/__tests__"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3389,6 +3389,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
+  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
+
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
@@ -3615,7 +3620,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
I added a some npm scripts to simplify the development workflow.

```bash
> npm run

  clean
    rimraf dist
  build
    npm run clean && tsc
  watch
    npm run build -- -w
```

I changed the `bin` entry to a named one: `chakra-codemod` to be able to execute it on the command line.

To test this run: 

```bash
yarn build
npm link
chakra-codemod
```

EDIT: ~~yarn link~~ to `npm link`

This prints the working directory.